### PR TITLE
Extend Exchanges API to use Symbol List and Delisted Symbols List

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,10 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
-        "mikey179/vfsstream": "^1.6"
+        "phpunit/phpunit": "^10.0",
+        "mikey179/vfsstream": "^1.6",
+        "vlucas/phpdotenv": "^5.6",
+        "ext-json": "*"
     },
     "extra": {
         "laravel": {

--- a/src/Api/Exchange.php
+++ b/src/Api/Exchange.php
@@ -7,6 +7,7 @@ use RadicalLoop\Eod\Traits\Actionable;
 class Exchange extends EodClient
 {
     use Actionable;
+
     /**
      * url segment for exchange api
      *
@@ -17,41 +18,74 @@ class Exchange extends EodClient
     /**
      * Set Get Exchange Symbols api
      * url : https://eodhistoricaldata.com/knowledgebase/list-symbols-exchange/
-     * @param string $symbol
-     * @param array $params
+     *
+     * @param  string  $symbol
+     * @param  array  $params
      * @return Exchange
      */
     public function symbol($symbol, $params = [])
     {
         $this->setParams($symbol, $params);
+
         return $this;
     }
 
     /**
      * Set Multiple Tickers api
      * url: https://eodhistoricaldata.com/knowledgebase/multiple-tickers-download/
-     * @param string $symbol
-     * @param array $params
+     *
+     * @param  string  $symbol
+     * @param  array  $params
      * @return Exchange
      */
     public function multipleTicker($symbol, $params = [])
     {
         $this->urlSegment = '/eod-bulk-last-day';
         $this->setParams($symbol, $params);
+
         return $this;
     }
-    
-     /**
+
+    /**
      * Get exchange details api
      * url: https://eodhistoricaldata.com/financial-apis/exchanges-api-trading-hours-and-holidays/
-     * @param string $symbol
-     * @param array $params
+     *
+     * @param  string  $symbol
+     * @param  array  $params
      * @return Exchange
      */
     public function details($symbol, $params = [])
     {
         $this->urlSegment = '/exchange-details';
         $this->setParams($symbol, $params);
+
+        return $this;
+    }
+
+    /**
+     * Get the full list of supported exchanges symbols with names, codes, operating MICs, country, and currency
+     * url: https://eodhd.com/financial-apis/exchanges-api-list-of-tickers-and-trading-hours
+     */
+    public function list(string $exchange, array $params = []): self
+    {
+        $this->urlSegment = '/exchange-symbol-list';
+        $this->setParams($exchange, $params);
+
+        return $this;
+    }
+
+    /**
+     * Get the list of inactive (delisted) tickers from an exchange
+     * url: https://eodhd.com/financial-apis/delisted-stock-companies-data
+     */
+    public function delisted(string $exchange, array $params = []): self
+    {
+        $this->urlSegment = '/exchange-symbol-list';
+
+        $params = array_merge($params, ['delisted' => 1]);
+
+        $this->setParams($exchange, $params);
+
         return $this;
     }
 }

--- a/tests/StockTest.php
+++ b/tests/StockTest.php
@@ -2,6 +2,7 @@
 use PHPUnit\Framework\TestCase;
 use RadicalLoop\Eod\Config;
 use RadicalLoop\Eod\Eod;
+use Dotenv\Dotenv;
 
 class StockTest extends TestCase
 {
@@ -10,7 +11,9 @@ class StockTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $apiToken = getenv('API_TOKEN');
+        $dotenv = Dotenv::createImmutable(__DIR__ . '/..');
+        $dotenv->load();
+        $apiToken = $_ENV['API_TOKEN'];
         $this->stock = (new Eod(new Config($apiToken)))->stock();
     }
 


### PR DESCRIPTION
Introduced `list` and `delisted` methods to fetch supported exchange symbols and delisted tickers, respectively. 

Upgraded phpunit to version 10.0 and added vlucas/phpdotenv to `require-dev`.